### PR TITLE
Initialize datacenter for all servers

### DIFF
--- a/src/main/java/com/krux/metrics/reporter/GraphiteReporter.java
+++ b/src/main/java/com/krux/metrics/reporter/GraphiteReporter.java
@@ -771,8 +771,8 @@ public class GraphiteReporter extends AbstractPollingReporter implements MetricP
             } else { //works for everyone
                 if (matchHost.equalsIgnoreCase(hostName)) {
                     isLeader = true;
-                    dc = "datacenter"; //should expose as config property
                 }
+                dc = "datacenter"; //should expose as config property
             }
         
             IS_LEADER = isLeader;


### PR DESCRIPTION
Datacenter field isn't initliazed for all servers which means that there will be NPE when pushing metrics to graphite. 
